### PR TITLE
Workaround for oneAPI internal compiler error

### DIFF
--- a/lib/psmile/src/mod_oasis_method.F90
+++ b/lib/psmile/src/mod_oasis_method.F90
@@ -614,6 +614,8 @@ CONTAINS
    character(len=*),parameter :: subname = 'oasis_get_intercomm'
 !  ---------------------------------------------------------
 
+!  Added by MS to try to circumvent ifx ICE
+   CHARACTER(len=:), ALLOCATABLE :: trim_compnm
    call oasis_debug_enter(subname)
    if (present(kinfo)) then
       kinfo = OASIS_OK
@@ -649,7 +651,9 @@ CONTAINS
        CALL oasis_flush(nulprt)
    ENDIF
 
-   tag=ICHAR(TRIM(compnm))+ICHAR(TRIM(cdnam))
+   trim_compnm=TRIM(compnm)
+   tag=ICHAR(trim_compnm)
+   tag=tag+ICHAR(TRIM(cdnam))
    CALL mpi_intercomm_create(mpi_comm_local, 0, MPI_COMM_WORLD, &
                              mpi_root_global(il), tag, new_comm, ierr)
 


### PR DESCRIPTION
Fixes the ICE for latest (?) oneAPI compilers. The applied fix worked for the latest version on gadi `oneAPI/2024.2.1`

Do not merge yet - need to confirm that the fix works for oneAPI 2025