### PR TITLE
Nesi changes to AVX2 flags

### DIFF
--- a/util/make_dir/make.nci
+++ b/util/make_dir/make.nci
@@ -42,7 +42,7 @@ ifeq ($(DEBUG), yes)
     CPPDEF          = -Duse_netCDF -Duse_comm_$(CHAN) -DTREAT_OVERLAY -DDEBUG -D__VERBOSE
     MCT_FCFLAGS     = $(NCI_REPRO_FLAGS) $(NCI_DEBUG_FLAGS) -ip
 else
-    NCI_OPTIM_FLAGS = -g3 -O2 -axCORE-AVX2 -debug all -check none -qopt-report=5 -qopt-report-annotate
+    NCI_OPTIM_FLAGS = -g3 -O2 -mavx2 -debug all -check none -qopt-report=5 -qopt-report-annotate
     F90FLAGS_1      = $(NCI_INTEL_FLAGS) $(NCI_REPRO_FLAGS) $(NCI_OPTIM_FLAGS)
     CPPDEF          = -Duse_netCDF -Duse_comm_$(CHAN) -DTREAT_OVERLAY
     MCT_FCFLAGS     = $(NCI_REPRO_FLAGS) $(NCI_OPTIM_FLAGS) -ip


### PR DESCRIPTION
Nesi changes to vectorization flags. See context here:
https://forum.access-hive.org.au/t/installing-access-om2-on-nesi-new-zealand-supercomputer/5566/53 