### PR TITLE
build-ci/manifests: copy CI manifests from access-spack-packages

### DIFF
--- a/.github/build-ci/manifests/gcc-oasis3-mct.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-oasis3-mct.spack.yaml.j2
@@ -1,0 +1,15 @@
+spack:
+  specs:
+  - 'oasis3-mct@git.{{ ref }}=stable'
+  - 'oasis3-mct@git.{{ ref }}=5.2'
+  packages:
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
+    all:
+      require:
+      - '%access_gcc'
+      - 'target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/intel-oasis3-mct.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-oasis3-mct.spack.yaml.j2
@@ -1,0 +1,15 @@
+spack:
+  specs:
+  - 'oasis3-mct@git.{{ ref }}=stable'
+  - 'oasis3-mct@git.{{ ref }}=5.2'
+  packages:
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
+    all:
+      require:
+      - '%access_intel'
+      - 'target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/oneapi-oasis3-mct.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-oasis3-mct.spack.yaml.j2
@@ -1,0 +1,15 @@
+spack:
+  specs:
+  - 'oasis3-mct@git.{{ ref }}=stable'
+  - 'oasis3-mct@git.{{ ref }}=5.2'
+  packages:
+    intel-oneapi-compilers:
+      require:
+      - '@{{ oneapi_compiler_version }}'
+    all:
+      require:
+      - '%access_oneapi'
+      - 'target={{ target }}'
+  concretizer:
+    unify: false
+  view: false


### PR DESCRIPTION
* Add a new oneapi CI manifest.
* This PR blocks https://github.com/ACCESS-NRI/access-spack-packages/pull/463